### PR TITLE
Add Club illustrations

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,11 +30,44 @@
 
 <!-- Club -->
 <section id="club" class="py-16 bg-gray-900">
-  <div class="container mx-auto px-4 grid md:grid-cols-2 gap-8">
-    <img src="https://via.placeholder.com/500x350" alt="Club" class="rounded-lg shadow-lg">
-    <div>
-      <h2 class="text-3xl text-cyan-400 font-bold mb-4">Notre Histoire</h2>
-      <p class="text-gray-300 mb-4">Fondé en 1996, Carcharias Boxing est un club emblématique de Perpignan. Forts de plusieurs décennies d'expérience, nous avons formé de nombreux champions nationaux et internationaux. Ouvert à tous les âges et niveaux, nous prônons des valeurs de rigueur, de respect et de dépassement de soi.</p>
+  <div class="container mx-auto px-4">
+    <h2 class="text-3xl text-center text-cyan-400 font-bold mb-4">Le Club</h2>
+    <img src="images/logocarcharias.png" alt="Logo du Club" class="mx-auto h-28 mb-8">
+
+    <div id="histoire" class="mb-12 grid md:grid-cols-2 gap-8 items-center">
+      <img src="images/boxe1.jpg" alt="Photo du Club" class="rounded-lg shadow-lg">
+      <div>
+        <h3 class="text-2xl text-cyan-400 font-semibold mb-2">Notre Histoire</h3>
+        <p class="text-gray-300">Fondé en 1996 à Perpignan, Carcharias Boxing est devenu une référence régionale. De nombreuses générations s'y sont succédé, partageant la même passion pour le ring.</p>
+      </div>
+    </div>
+
+    <div id="valeurs" class="mb-12">
+      <h3 class="text-2xl text-cyan-400 font-semibold mb-2">Nos Valeurs</h3>
+      <p class="text-gray-300">Respect, discipline et entraide sont au cœur de notre pratique. Chaque adhérent progresse à son rythme dans une ambiance bienveillante.</p>
+    </div>
+
+    <div id="reussites" class="mb-12">
+      <h3 class="text-2xl text-cyan-400 font-semibold mb-2">Nos Réussites</h3>
+      <p class="text-gray-300">Le club compte plusieurs champions régionaux et nationaux. Ces succès témoignent de la qualité de notre enseignement et de l'engagement de nos boxeurs.</p>
+    </div>
+
+    <div id="projets" class="mb-12">
+      <h3 class="text-2xl text-cyan-400 font-semibold mb-2">Objectifs</h3>
+      <p class="text-gray-300">Nous souhaitons développer la pratique chez les jeunes et participer davantage aux événements internationaux.</p>
+    </div>
+
+    <div id="encadrement" class="mb-12">
+      <h3 class="text-2xl text-cyan-400 font-semibold mb-2">Encadrement</h3>
+      <p class="text-gray-300">Une équipe d'entraîneurs diplômés accompagne les sportifs, des débutants aux compétiteurs confirmés.</p>
+    </div>
+
+    <div id="organigramme" class="mb-12 grid md:grid-cols-2 gap-8 items-center">
+      <div>
+        <h3 class="text-2xl text-cyan-400 font-semibold mb-2">Organigramme</h3>
+        <p class="text-gray-300">Le club est dirigé par un président assisté d'un bureau actif et de bénévoles passionnés.</p>
+      </div>
+      <img src="images/boxe2.jpg" alt="Équipe encadrante" class="rounded-lg shadow-lg">
     </div>
   </div>
 </section>
@@ -87,6 +120,15 @@
           </tr>
         </tbody>
       </table>
+    </div>
+    <div class="mt-6 text-gray-300">
+      <p class="mb-2 font-semibold">Pensez &agrave; prendre avec vous&nbsp;:</p>
+      <ul class="list-disc list-inside space-y-1">
+        <li>gants, bandages et prot&egrave;ge-dents obligatoires</li>
+        <li>casque ou coquille selon votre pratique</li>
+        <li>&eacute;quipements facultatifs&nbsp;: corde &agrave; sauter, serviette personnelle, etc.</li>
+        <li>une bouteille d'eau et de quoi se doucher sur place</li>
+      </ul>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- tweak **Club** section layout and add the club logo
- show a local photo for the history subsection
- include a picture next to the organigram

## Testing
- `git show --stat -1`


------
https://chatgpt.com/codex/tasks/task_e_68692a9563e8832ea85dbaf671cdb4bd